### PR TITLE
Add keyword check to RENAME_SEQUENCES process

### DIFF
--- a/modules/custom/rename_sequences.nf
+++ b/modules/custom/rename_sequences.nf
@@ -15,6 +15,12 @@ process RENAME_SEQUENCES {
 
     script:
     """
+    if ! grep -c "#unknown" $fasta; then
+        echo "Key word #unknown not found."
+        echo "Please check your output is from RepeatModeler2."
+        exit 1
+    fi
+
     renameRMDLconsensi.pl $fasta $sci_name ${sci_name}.fasta
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/custom/rename_sequences.nf
+++ b/modules/custom/rename_sequences.nf
@@ -15,8 +15,8 @@ process RENAME_SEQUENCES {
 
     script:
     """
-    if ! grep -c "#unknown" $fasta; then
-        echo "Key word #unknown not found."
+    if ! grep -c "#Unknown" $fasta; then
+        echo "Key word #Unknown not found."
         echo "Please check your output is from RepeatModeler2."
         exit 1
     fi


### PR DESCRIPTION
Added a check to the process `RENAME_SEQUENCES` which throws an error if the keyword '#unknown' is not found in the input file. This should stop the workflow early in the case the input is not as expected. 